### PR TITLE
Add the Space Exploration Plague Rocket to the  kills milestone section

### DIFF
--- a/presets/presets.lua
+++ b/presets/presets.lua
@@ -136,6 +136,7 @@ presets = {
             {type="kill",       name="big-biter",                    quantity=1},
             {type="kill",       name="behemoth-biter",               quantity=1},
             {type="kill",       name="behemoth-biter",               quantity=1000, next="x10"},
+            {type="item",       name="se-plague-bomb",               quantity=1},
             {type="kill",       name="character",                    quantity=1, next="x5"},
         }
     },
@@ -268,6 +269,7 @@ presets = {
             {type="kill",       name="big-biter",                    quantity=1},
             {type="kill",       name="behemoth-biter",               quantity=1},
             {type="kill",       name="behemoth-biter",               quantity=1000, next="x10"},
+            {type="item",       name="se-plague-bomb",               quantity=1},
             {type="kill",       name="character",                    quantity=1, next="x5"},
         }
     },


### PR DESCRIPTION
Added for SE and SE+K2

It seems like wiping out a whole planet deserves an entry in the Milestones?

It's tempting to use the item for delivering a plague rocket via weapon delivery capsule, but I think you can also manually fire the plague rocket, so recording it when you make a plague rocket seems more reliable?