### PR TITLE
Updated most locales to fix formatting

### DIFF
--- a/locale/ca/milestones.cfg
+++ b/locale/ca/milestones.cfg
@@ -92,13 +92,13 @@ message_reloaded_presets_plural=[img=milestones_main_icon_white] [font=default-l
 message_settings_changed=[img=milestones_main_icon_white] Configuració de [font=default-large-bold]Milestones[/font] canviada!
 message_settings_changed_multiplayer=[img=milestones_main_icon_white] Configuració de [font=default-large-bold]Milestones[/font] canviada per __1__!
 message_settings_backfilled=Els temps d'assoliment de les noves fites s'han estimat retroactivament a partir de les estadístiques de producció.
-message_milestone_reached_item_first=[img=milestones_main_icon_white] [font=default-large-bold]S'ha creat el primer ítem de [color=green][img=__1__]__2__[/color] a [color=green]__3__[img=quantity-time][/color]![/font]
-message_milestone_reached_item_more=[img=milestones_main_icon_white] [font=default-large-bold]S'ha creat [color=green]__1__ [img=__2__]__3__[/color] a [color=green]__4__[img=quantity-time][/color]![/font]
-message_milestone_reached_consumption_first=[img=milestones_main_icon_white] [font=default-large-bold]S'ha consumit el primer ítem de [color=green][img=__1__]__2__[/color] a [color=green]__3__[img=quantity-time][/color]![/font]
-message_milestone_reached_consumption_more=[img=milestones_main_icon_white] [font=default-large-bold]S'ha consumit [color=green]__1__ [img=__2__]__3__[/color] a [color=green]__4__[img=quantity-time][/color]![/font]
-message_milestone_reached_kill_first=[img=milestones_main_icon_white] [font=default-large-bold]S'ha matat el primer [color=green][img=__1__]__2__[/color] a [color=green]__3__[img=quantity-time][/color]![/font]
-message_milestone_reached_kill_more=[img=milestones_main_icon_white] [font=default-large-bold]S'ha matat [color=green]__1__ [img=__2__]__3__[/color] a [color=green]__4__[img=quantity-time][/color]![/font]
-message_milestone_reached_technology=[img=milestones_main_icon_white] [font=default-large-bold]S'ha recercat [color=green][img=__1__]__2____3__[/color] a [color=green]__4__[img=quantity-time][/color]![/font]
+message_milestone_reached_item_first=[img=milestones_main_icon_white] [font=default-large-bold]S'ha creat el primer ítem de [color=green]__1__[/color] a [color=green]__2__[img=quantity-time][/color]![/font]
+message_milestone_reached_item_more=[img=milestones_main_icon_white] [font=default-large-bold]S'ha creat [color=green]__1__ __2__[/color] a [color=green]__3__[img=quantity-time][/color]![/font]
+message_milestone_reached_consumption_first=[img=milestones_main_icon_white] [font=default-large-bold]S'ha consumit el primer ítem de [color=green]__1__[/color] a [color=green]__2__[img=quantity-time][/color]![/font]
+message_milestone_reached_consumption_more=[img=milestones_main_icon_white] [font=default-large-bold]S'ha consumit [color=green]__1__ __2__[/color] a [color=green]__3__[img=quantity-time][/color]![/font]
+message_milestone_reached_kill_first=[img=milestones_main_icon_white] [font=default-large-bold]S'ha matat el primer [color=green]__1__[/color] a [color=green]__2__[img=quantity-time][/color]![/font]
+message_milestone_reached_kill_more=[img=milestones_main_icon_white] [font=default-large-bold]S'ha matat [color=green]__1__ __2__[/color] a [color=green]__3__[img=quantity-time][/color]![/font]
+message_milestone_reached_technology=[img=milestones_main_icon_white] [font=default-large-bold]S'ha recercat [color=green]__1____2__[/color] a [color=green]__3__[img=quantity-time][/color]![/font]
 message_settings_permission_denied=[color=red]No es pot canviar la configuració de Milestones. Necessiteu permisos d'administrador.[/color]
 message_invalid_import_json=[color=red]Text d'importació no vàlid. El text no és JSON vàlid ni és una cadena codificada.[/color]
 message_invalid_import_type=[color=red]Text d'importació no vàlid. Tipus invàlid: [/color]

--- a/locale/cs/milestones.cfg
+++ b/locale/cs/milestones.cfg
@@ -85,11 +85,11 @@ message_reloaded_presets_plural=[img=milestones_main_icon_white] [font=default-l
 message_settings_changed=[img=milestones_main_icon_white] [font=default-large-bold]Milníky[/font] se změnily!
 message_settings_changed_multiplayer=[img=milestones_main_icon_white] [font=default-large-bold]Milestones[/font] nastavení změněno __1__!
 message_settings_backfilled=Časy dokončení nových milníků byly doplněny pomocí výrobních statistik.
-message_milestone_reached_item_first=[img=milestones_main_icon_white] [font=default-large-bold]Dosáhnul první [color=green][img=__1__]__2__[/color] v [color=green]__3__[img=quantity-time][/color]![/font]
-message_milestone_reached_item_more=[img=milestones_main_icon_white] [font=default-large-bold]Dosaženo [color=green]__1__ [img=__2__]__3__[/color] v [color=green]__4__[img=quantity-time][/color]![/font]
-message_milestone_reached_kill_first=[img=milestones_main_icon_white] [font=default-large-bold]Poprvé zabito [color=green][img=__1__]__2__[/color] v [color=green]__3__[img=quantity-time][/color]![/font]
-message_milestone_reached_kill_more=[img=milestones_main_icon_white] [font=default-large-bold]Zabito [color=green]__1__ [img=__2__]__3__[/color] v [color=green]__4__[img=quantity-time][/color]![/font]
-message_milestone_reached_technology=[img=milestones_main_icon_white] [font=default-large-bold]Vyzkoumáno [color=green][img=__1__]__2____3__[/color] v [color=green]__4__[img=quantity-time][/color]![/font]
+message_milestone_reached_item_first=[img=milestones_main_icon_white] [font=default-large-bold]Dosáhnul první [color=green]__1__[/color] v [color=green]__2__[img=quantity-time][/color]![/font]
+message_milestone_reached_item_more=[img=milestones_main_icon_white] [font=default-large-bold]Dosaženo [color=green]__1__ __2__[/color] v [color=green]__3__[img=quantity-time][/color]![/font]
+message_milestone_reached_kill_first=[img=milestones_main_icon_white] [font=default-large-bold]Poprvé zabito [color=green]__1__[/color] v [color=green]__2__[img=quantity-time][/color]![/font]
+message_milestone_reached_kill_more=[img=milestones_main_icon_white] [font=default-large-bold]Zabito [color=green]__1__ __2__[/color] v [color=green]__3__[img=quantity-time][/color]![/font]
+message_milestone_reached_technology=[img=milestones_main_icon_white] [font=default-large-bold]Vyzkoumáno [color=green]__1____2__[/color] v [color=green]__3__[img=quantity-time][/color]![/font]
 message_settings_permission_denied=Nastavení milníků nelze změnit. Potřebujete oprávnění správce.[/color]
 message_invalid_import_json=[color=red]Neplatný řetězec importu. Tento řetězec není platný JSON řetězec nebo kódovaný řetězec.[/color]
 message_invalid_import_type=Neplatný importní řetězec. Neplatný typ: [/color]

--- a/locale/de/milestones.cfg
+++ b/locale/de/milestones.cfg
@@ -82,11 +82,11 @@ message_reloaded_presets_plural=[img=milestones_main_icon_white] [font=default-l
 message_settings_changed=[img=milestones_main_icon_white] [font=default-large-bold]Meilensteine[/font] Einstellungen geändert!
 message_settings_changed_multiplayer=[img=milestones_main_icon_white] [font=default-large bold]Meilensteine[/font] Einstellungen geändert von __1__!
 message_settings_backfilled=Die Fertigstellungszeiten für neue Meilensteine wurden anhand von Produktionsstatistiken zurückgeführt.
-message_milestone_reached_item_first=[img=milestones_main_icon_white] [font=default-large-bold]Den ersten[color=green][img=__1__]__2__[/color] hergestellt bei[color=green]__3__[img=quantity-time][/color]![/font]
-message_milestone_reached_item_more=[img=milestones_main_icon_white] [font=default-large-bold]Erstellt [color=green]__1__ [img=__2__]__3__[/color] bei [color=green]__4__[img=quantity-time][/color]![/font]
-message_milestone_reached_kill_first=[img=milestones_main_icon_white] [font=default-large-bold]Den ersten [color=green][img=__1__]__2__[/color] getötet bei [color=green]__3__[img=quantity-time][/color]![/font]
-message_milestone_reached_kill_more=[img=milestones_main_icon_white] [font=default-large-bold]Getötet [color=green]__1__ [img=__2__]__3__[/color] bei [color=green]__4__[img=quantity-time][/color]![/font]
-message_milestone_reached_technology=[img=milestones_main_icon_white] [font=default-large-bold]Erforscht [color=green][img=__1__]__2____3__[/color] bei [color=green]__4__[img=quantity-time][/color]![/font]
+message_milestone_reached_item_first=[img=milestones_main_icon_white] [font=default-large-bold]Den ersten[color=green]__1__[/color] hergestellt bei[color=green]__2__[img=quantity-time][/color]![/font]
+message_milestone_reached_item_more=[img=milestones_main_icon_white] [font=default-large-bold]Erstellt [color=green]__1__ __2__[/color] bei [color=green]__3__[img=quantity-time][/color]![/font]
+message_milestone_reached_kill_first=[img=milestones_main_icon_white] [font=default-large-bold]Den ersten [color=green]__1__[/color] getötet bei [color=green]__2__[img=quantity-time][/color]![/font]
+message_milestone_reached_kill_more=[img=milestones_main_icon_white] [font=default-large-bold]Getötet [color=green]__1__ __2__[/color] bei [color=green]__3__[img=quantity-time][/color]![/font]
+message_milestone_reached_technology=[img=milestones_main_icon_white] [font=default-large-bold]Erforscht [color=green]__1____2__[/color] bei [color=green]__3__[img=quantity-time][/color]![/font]
 message_settings_permission_denied=[color=red]Die Meilensteineinstellungen können nicht geändert werden. Du benötigst Administratorrechte.[/color]
 message_invalid_import_json=[color=red]Ungültiger Import-String. Dieser String ist kein gültiger JSON-String oder kodierter String.[/color]
 message_invalid_import_type=[color=red]Ungültiger Import-String. Ungültiger Typ: [/color]

--- a/locale/es-ES/milestones.cfg
+++ b/locale/es-ES/milestones.cfg
@@ -83,11 +83,11 @@ message_reloaded_presets_plural=[img=milestones_main_icon_white] [font=default-l
 message_settings_changed=[img=milestones_main_icon_white]¡Ajustes de [font=default-large-bold]Hitos[/font] cambiados!
 message_settings_changed_multiplayer=[img=milestones_main_icon_white] ¡Ajustes de [font=default-large-bold]Hitos[/font] cambiados por __1__!
 message_settings_backfilled=Los tiempos de finalización de los nuevos hitos se rellenaron usando estadísticas de producción.
-message_milestone_reached_item_first=[img=milestones_main_icon_white] [font=default-large-bold]¡Creado el primer [color=green][img=__1__]__2__[/color] en [color=green]__3__[img=quantity-time][/color]![/font]
-message_milestone_reached_item_more=[img=milestones_main_icon_white] [font=default-large-bold]¡Creado [color=green]__1__ [img=__2__]__3__[/color] en [color=green]__4__[img=quantity-time][/color]![/font]
-message_milestone_reached_kill_first=[img=milestones_main_icon_white] [font=default-large-bold]¡Matado el primer [color=green][img=__1__]__2__[/color] en [color=green]__3__[img=quantity-time][/color]![/font]
-message_milestone_reached_kill_more=[img=milestones_main_icon_white] [font=default-large-bold]¡Matado [color=green]__1__ [img=__2__]__3__[/color] en [color=green]__4__[img=quantity-time][/color]![/font]
-message_milestone_reached_technology=[img=milestones_main_icon_white] [font=default-large-bold]¡Investigado [color=green][img=__1__]__2____3__[/color] en [color=green]__4__[img=quantity-time][/color]![/font]
+message_milestone_reached_item_first=[img=milestones_main_icon_white] [font=default-large-bold]¡Creado el primer [color=green]__1__[/color] en [color=green]__2__[img=quantity-time][/color]![/font]
+message_milestone_reached_item_more=[img=milestones_main_icon_white] [font=default-large-bold]¡Creado [color=green]__1__ __2__[/color] en [color=green]__3__[img=quantity-time][/color]![/font]
+message_milestone_reached_kill_first=[img=milestones_main_icon_white] [font=default-large-bold]¡Matado el primer [color=green]__1__[/color] en [color=green]__2__[img=quantity-time][/color]![/font]
+message_milestone_reached_kill_more=[img=milestones_main_icon_white] [font=default-large-bold]¡Matado [color=green]__1__ __2__[/color] en [color=green]__3__[img=quantity-time][/color]![/font]
+message_milestone_reached_technology=[img=milestones_main_icon_white] [font=default-large-bold]¡Investigado [color=green]__1____2__[/color] en [color=green]__3__[img=quantity-time][/color]![/font]
 message_settings_permission_denied=[color=red]No se pueden cambiar los ajustes de hitos. Necesitas permisos de administrador.[/color]
 message_invalid_import_json=[color=red]Cadena de importación inválida. Esta cadena no es una cadena JSON válida o cadena codificada.[/color]
 message_invalid_import_type=[color=red]Cadena de importación inválida. Tipo no válido: [/color]

--- a/locale/fr/milestones.cfg
+++ b/locale/fr/milestones.cfg
@@ -92,13 +92,13 @@ message_reloaded_presets_plural=[img=milestones_main_icon_white] [font=default-l
 message_settings_changed=[img=milestones_main_icon_white] Les paramètres de [font=default-large-bold]Milestones[/font] ont été modifiés !
 message_settings_changed_multiplayer=[img=milestones_main_icon_white] Les paramètres de [font=default-large-bold]Milestones[/font] ont été modifiés par __1__ !
 message_settings_backfilled=Les temps déjà achevés ont ètè remplis rétroactivement grâce aux statistiques de production.
-message_milestone_reached_item_first=[img=milestones_main_icon_white] [font=default-large-bold]Créé le premier [color=green][img=__1__]__2__[/color] à [color=green]__3__[img=quantity-time][/color] ![/font]
-message_milestone_reached_item_more=[img=milestones_main_icon_white] [font=default-large-bold]Créé [color=green]__1__ [img=__2__]__3__[/color] à [color=green]__4__[img=quantity-time][/color] ![/font]
-message_milestone_reached_consumption_first=[img=milestones_main_icon_white] [font=default-large-bold]Premier(ère)[color=green][img=__1__]__2__[/color] consommé(e) après [color=green]__3__[img=quantity-time][/color]![/font]
-message_milestone_reached_consumption_more=[img=milestones_main_icon_white] [font=default-large-bold]Déjà [color=green]__1__ [img=__2__]__3__[/color] consommés après [color=green]__4__[img=quantity-time][/color]![/font]
-message_milestone_reached_kill_first=[img=milestones_main_icon_white] [font=default-large-bold]Tué le premier [color=green][img=__1__]__2__[/color] à [color=green]__3__[img=quantity-time][/color] ![/font]
-message_milestone_reached_kill_more=[img=milestones_main_icon_white] [font=default-large-bold]Tué [color=green]__1__ [img=__2__]__3__[/color] à [color=green]__4__[img=quantity-time][/color] ![/font]
-message_milestone_reached_technology=[img=milestones_main_icon_white] [font=default-large-bold]Recherché [color=green][img=__1__]__2____3__[/color] à [color=green]__4__[img=quantity-time][/color] ![/font]
+message_milestone_reached_item_first=[img=milestones_main_icon_white] [font=default-large-bold]Créé le premier [color=green]__1__[/color] à [color=green]__2__[img=quantity-time][/color] ![/font]
+message_milestone_reached_item_more=[img=milestones_main_icon_white] [font=default-large-bold]Créé [color=green]__1__ __2__[/color] à [color=green]__3__[img=quantity-time][/color] ![/font]
+message_milestone_reached_consumption_first=[img=milestones_main_icon_white] [font=default-large-bold]Premier(ère)[color=green]__1__[/color] consommé(e) après [color=green]__2__[img=quantity-time][/color]![/font]
+message_milestone_reached_consumption_more=[img=milestones_main_icon_white] [font=default-large-bold]Déjà [color=green]__1__ __2__[/color] consommés après [color=green]__3__[img=quantity-time][/color]![/font]
+message_milestone_reached_kill_first=[img=milestones_main_icon_white] [font=default-large-bold]Tué le premier [color=green]__1__[/color] à [color=green]__2__[img=quantity-time][/color] ![/font]
+message_milestone_reached_kill_more=[img=milestones_main_icon_white] [font=default-large-bold]Tué [color=green]__1__ __2__[/color] à [color=green]__3__[img=quantity-time][/color] ![/font]
+message_milestone_reached_technology=[img=milestones_main_icon_white] [font=default-large-bold]Recherché [color=green]__1____2__[/color] à [color=green]__3__[img=quantity-time][/color] ![/font]
 message_settings_permission_denied=[color=red]Vous ne pouvez pas changer les paramètres de Milestones. Vous n'êtes pas Administrateur.[/color]
 message_invalid_import_json=[color=red]Texte importé non valide. The texte n'est pas un JSON valide ou une liste encodée.[/color]
 message_invalid_import_type=[color=red]Texte importé non valide. Valeur "type" invalide : [/color]

--- a/locale/ja/milestones.cfg
+++ b/locale/ja/milestones.cfg
@@ -92,13 +92,13 @@ message_reloaded_presets_plural=[img=milestones_main_icon_white] [font=default-l
 message_settings_changed=[img=milestones_main_icon_white] [font=default-large-bold]マイルストーン[/font]の設定が変更されました！
 message_settings_changed_multiplayer=[img=milestones_main_icon_white] [font=default-large-bold]マイルストーン[/font]の設定が __1__ によって変更されました！
 message_settings_backfilled=新しいマイルストーンの達成時間は、生産統計を使用して遡って記入されました。
-message_milestone_reached_item_first=[img=milestones_main_icon_white] [font=default-large-bold]最初の[color=green][img=__1__]__2__[/color]が、[color=green]__3__[img=quantity-time][/color]に作成されました！[/font]
-message_milestone_reached_item_more=[img=milestones_main_icon_white] [font=default-large-bold][color=green]__1__ [img=__2__]__3__[/color]が、[color=green]__4__[img=quantity-time][/color]に作成されました！[/font]
-message_milestone_reached_consumption_first=[img=milestones_main_icon_white] [font=default-large-bold]最初の[color=green][img=__1__]__2__[/color]が、[color=green]__3__[img=quantity-time][/color]に消費されました！[/font]
-message_milestone_reached_consumption_more=[img=milestones_main_icon_white] [font=default-large-bold][color=green]__1__ [img=__2__]__3__[/color]が、[color=green]__4__[img=quantity-time][/color]に消費されました！[/font]
-message_milestone_reached_kill_first=[img=milestones_main_icon_white] [font=default-large-bold]初めて[color=green][img=__1__]__2__[/color]が、[color=green]__3__[img=quantity-time][/color]に討伐されました！[/font]
-message_milestone_reached_kill_more=[img=milestones_main_icon_white] [font=default-large-bold][color=green]__1__ [img=__2__]__3__[/color]が、[color=green]__4__[img=quantity-time][/color]に討伐されました！[/font]
-message_milestone_reached_technology=[img=milestones_main_icon_white] [font=default-large-bold][color=green][img=__1__]__2____3__[/color]が、[color=green]__4__[img=quantity-time][/color]に研究されました！[/font]
+message_milestone_reached_item_first=[img=milestones_main_icon_white] [font=default-large-bold]最初の[color=green]__1__[/color]が、[color=green]__2__[img=quantity-time][/color]に作成されました！[/font]
+message_milestone_reached_item_more=[img=milestones_main_icon_white] [font=default-large-bold][color=green]__1__ __2__[/color]が、[color=green]__3__[img=quantity-time][/color]に作成されました！[/font]
+message_milestone_reached_consumption_first=[img=milestones_main_icon_white] [font=default-large-bold]最初の[color=green]__1__[/color]が、[color=green]__2__[img=quantity-time][/color]に消費されました！[/font]
+message_milestone_reached_consumption_more=[img=milestones_main_icon_white] [font=default-large-bold][color=green]__1__ __2__[/color]が、[color=green]__3__[img=quantity-time][/color]に消費されました！[/font]
+message_milestone_reached_kill_first=[img=milestones_main_icon_white] [font=default-large-bold]初めて[color=green]__1__[/color]が、[color=green]__2__[img=quantity-time][/color]に討伐されました！[/font]
+message_milestone_reached_kill_more=[img=milestones_main_icon_white] [font=default-large-bold][color=green]__1__ __2__[/color]が、[color=green]__3__[img=quantity-time][/color]に討伐されました！[/font]
+message_milestone_reached_technology=[img=milestones_main_icon_white] [font=default-large-bold][color=green]__1____2__[/color]が、[color=green]__3__[img=quantity-time][/color]に研究されました！[/font]
 message_settings_permission_denied=[color=red]マイルストーンの設定は変更できません。管理者権限が必要です。[/color]
 message_invalid_import_json=[color=red]無効なインポート文字列です。この文字列は有効なJSON文字列、またはエンコード文字列ではありません。[/color]
 message_invalid_import_type=[color=red]無効なインポート文字列です。無効なタイプ: [/color]

--- a/locale/pl/milestones.cfg
+++ b/locale/pl/milestones.cfg
@@ -83,11 +83,11 @@ message_reloaded_presets_plural=[img=milestones_main_icon_white] [font=default-l
 message_settings_changed=[img=milestones_main_icon_white] [font=default-large-bold]Kamienie milowe[/font] ustawienia zostały zmienione!
 message_settings_changed_multiplayer=[img=milestones_main_icon_white] [font=default-large-bold]Kamienie milowe[/font] ustawienia zmienione przez __1__!
 message_settings_backfilled=Czasy ukończenia nowych kamieni milowych zostały obliczone na podstawie danych dotyczących produkcji.
-message_milestone_reached_item_first=[img=milestones_main_icon_white] [font=default-large-bold]Utworzono pierwszy [color=green][img=__1__]__2__[/color] w [color=green]__3__[img=quantity-time][/color]![/font]
-message_milestone_reached_item_more=[img=milestones_main_icon_white] [font=default-large-bold]Utworzono [color=green]__1__ [img=__2__]__3__[/color] w [color=green]__4__[img=quantity-time][/color]![/font]
-message_milestone_reached_kill_first=[img=milestones_main_icon_white] [font=default-large-bold]Zabito pierwszego [color=green][img=__1__]__2__[/color] w [color=green]__3__[img=quantity-time][/color]![/font]
-message_milestone_reached_kill_more=[img=milestones_main_icon_white] [font=default-large-bold]Zabito [color=green]__1__ [img=__2__]__3__[/color] w [color=green]__4__[img=quantity-time][/color]![/font]
-message_milestone_reached_technology=[img=milestones_main_icon_white] [font=default-large-bold]Zbadano [color=green][img=__1__]__2____3__[/color] w [color=green]__4__[img=quantity-time][/color]![/font]
+message_milestone_reached_item_first=[img=milestones_main_icon_white] [font=default-large-bold]Utworzono pierwszy [color=green]__1__[/color] w [color=green]__2__[img=quantity-time][/color]![/font]
+message_milestone_reached_item_more=[img=milestones_main_icon_white] [font=default-large-bold]Utworzono [color=green]__1__ __2__[/color] w [color=green]__3__[img=quantity-time][/color]![/font]
+message_milestone_reached_kill_first=[img=milestones_main_icon_white] [font=default-large-bold]Zabito pierwszego [color=green]__1__[/color] w [color=green]__2__[img=quantity-time][/color]![/font]
+message_milestone_reached_kill_more=[img=milestones_main_icon_white] [font=default-large-bold]Zabito [color=green]__1__ __2__[/color] w [color=green]__3__[img=quantity-time][/color]![/font]
+message_milestone_reached_technology=[img=milestones_main_icon_white] [font=default-large-bold]Zbadano [color=green]__1____2__[/color] w [color=green]__3__[img=quantity-time][/color]![/font]
 message_settings_permission_denied=[color=red]Nie można zmienić ustawień kamienia milowego. Potrzebujesz uprawnień administratora.[/color]
 message_invalid_import_json=[color=red]Nieprawidłowy ciąg importu. Ten ciąg nie jest prawidłowym ciągiem JSON lub zakodowanym ciągiem.[/color]
 message_invalid_import_type=[color=red]Nieprawidłowy ciąg importu. Nieprawidłowy typ: [/color]

--- a/locale/ru/milestones.cfg
+++ b/locale/ru/milestones.cfg
@@ -92,13 +92,13 @@ message_reloaded_presets_plural=[img=milestones_main_icon_white] [font=default-l
 message_settings_changed=[img=milestones_main_icon_white] Настройки [font=default-large-bold]Этапов[/font] изменены!
 message_settings_changed_multiplayer=[img=milestones_main_icon_white] Настройки [font=default-large-bold]Этапов[/font] изменены игроком __1__!
 message_settings_backfilled=Время завершения новых этапов было заполнено из статистики производства.
-message_milestone_reached_item_first=[img=milestones_main_icon_white] [font=default-large-bold]Создал первый [color=green][img=__1__]__2__[/color] в [color=green]__3__[img=quantity-time][/color]![/font]
-message_milestone_reached_item_more=[img=milestones_main_icon_white] [font=default-large-bold]Создано [color=green]__1__ [img=__2__]__3__[/color] в [color=green]__4__[img=quantity-time][/color]![/font]
-message_milestone_reached_consumption_first=[img=milestones_main_icon_white] [font=default-large-bold]Потребил первый [color=green][img=__1__]__2__[/color] в [color=green]__3__[img=quantity-time][/color]![/font]
-message_milestone_reached_consumption_more=[img=milestones_main_icon_white] [font=default-large-bold]Потребил [color=green]__1__ [img=__2__]__3__[/color] в [color=green]__4__[img=quantity-time][/color]![/font]
-message_milestone_reached_kill_first=[img=milestones_main_icon_white] [font=default-large-bold]Убил первого [color=green][img=__1__]__2__[/color] в [color=green]__3__[img=quantity-time][/color]![/font]
-message_milestone_reached_kill_more=[img=milestones_main_icon_white] [font=default-large-bold]Убито [color=green]__1__ [img=__2__]__3__[/color] в [color=green]__4__[img=quantity-time][/color]![/font]
-message_milestone_reached_technology=[img=milestones_main_icon_white] [font=default-large-bold]Исследовано [color=green][img=__1__]__2____3__[/color] в [color=green]__4__[img=quantity-time][/color]![/font]
+message_milestone_reached_item_first=[img=milestones_main_icon_white] [font=default-large-bold]Создал первый [color=green]__1__[/color] в [color=green]__2__[img=quantity-time][/color]![/font]
+message_milestone_reached_item_more=[img=milestones_main_icon_white] [font=default-large-bold]Создано [color=green]__1__ __2__[/color] в [color=green]__3__[img=quantity-time][/color]![/font]
+message_milestone_reached_consumption_first=[img=milestones_main_icon_white] [font=default-large-bold]Потребил первый [color=green]__1__[/color] в [color=green]__2__[img=quantity-time][/color]![/font]
+message_milestone_reached_consumption_more=[img=milestones_main_icon_white] [font=default-large-bold]Потребил [color=green]__1__ __2__[/color] в [color=green]__3__[img=quantity-time][/color]![/font]
+message_milestone_reached_kill_first=[img=milestones_main_icon_white] [font=default-large-bold]Убил первого [color=green]__1__[/color] в [color=green]__2__[img=quantity-time][/color]![/font]
+message_milestone_reached_kill_more=[img=milestones_main_icon_white] [font=default-large-bold]Убито [color=green]__1__ __2__[/color] в [color=green]__3__[img=quantity-time][/color]![/font]
+message_milestone_reached_technology=[img=milestones_main_icon_white] [font=default-large-bold]Исследовано [color=green]__1____2__[/color] в [color=green]__3__[img=quantity-time][/color]![/font]
 message_settings_permission_denied=[color=red]Невозможно изменить настройки этапов. Вам нужны права администратора.[/color]
 message_invalid_import_json=[color=red]Неверная строка импорта. Эта строка не является допустимой строкой JSON или закодированной строкой.[/color]
 message_invalid_import_type=[color=red]Неверная строка импорта. Неверный тип: [/color]

--- a/locale/uk/milestones.cfg
+++ b/locale/uk/milestones.cfg
@@ -92,13 +92,13 @@ message_reloaded_presets_plural=[img=milestones_main_icon_white] [font=default-l
 message_settings_changed=[img=milestones_main_icon_white] [font=default-large-bold]Milestones[/font] налаштування змінено!
 message_settings_changed_multiplayer=[img=milestones_main_icon_white] [font=default-large-bold]Milestones[/font] налаштування змінено на __1__!
 message_settings_backfilled=Терміни виконання нових етапів були визначені на основі виробничої статистики.
-message_milestone_reached_item_first=[img=milestones_main_icon_white] [font=default-large-bold]Створено перший [color=green][img=__1__]__2__[/color] на [color=green]__3__[img=quantity-time][/color]![/font]
-message_milestone_reached_item_more=[img=milestones_main_icon_white] [font=default-large-bold]Створено [color=green]__1__ [img=__2__]__3__[/color] на [color=green]__4__[img=quantity-time][/color]![/font]
-message_milestone_reached_consumption_first=[img=milestones_main_icon_white] [font=default-large-bold]Спожито перший [color=green][img=__1__]__2__[/color] о [color=green]__3__[img=quantity-time][/color]![/font]
-message_milestone_reached_consumption_more=[img=milestones_main_icon_white] [font=default-large-bold]Спожито[color=green]__1__ [img=__2__]__3__[/color] за адресою[color=green]__4__[img=quantity-time][/color]![/font]
-message_milestone_reached_kill_first=[img=milestones_main_icon_white] [font=default-large-bold]Вбив першого [color=green][img=__1__]__2__[/color] на [color=green]__3__[img=quantity-time][/color]![/font]
-message_milestone_reached_kill_more=[img=milestones_main_icon_white] [font=default-large-bold]Вбито [color=green]__1__ [img=__2__]__3__[/color] на [color=green]__4__[img=quantity-time][/color]![/font]
-message_milestone_reached_technology=[img=milestones_main_icon_white] [font=default-large-bold]Досліджено [color=green][img=__1__]__2____3__[/color] на [color=green]__4__[img=quantity-time][/color]![/font]
+message_milestone_reached_item_first=[img=milestones_main_icon_white] [font=default-large-bold]Створено перший [color=green]__1__[/color] на [color=green]__2__[img=quantity-time][/color]![/font]
+message_milestone_reached_item_more=[img=milestones_main_icon_white] [font=default-large-bold]Створено [color=green]__1__ __2__[/color] на [color=green]__3__[img=quantity-time][/color]![/font]
+message_milestone_reached_consumption_first=[img=milestones_main_icon_white] [font=default-large-bold]Спожито перший [color=green]__1__[/color] о [color=green]__2__[img=quantity-time][/color]![/font]
+message_milestone_reached_consumption_more=[img=milestones_main_icon_white] [font=default-large-bold]Спожито[color=green]__1__ __2__[/color] за адресою[color=green]__3__[img=quantity-time][/color]![/font]
+message_milestone_reached_kill_first=[img=milestones_main_icon_white] [font=default-large-bold]Вбив першого [color=green]__1__[/color] на [color=green]__2__[img=quantity-time][/color]![/font]
+message_milestone_reached_kill_more=[img=milestones_main_icon_white] [font=default-large-bold]Вбито [color=green]__1__ __2__[/color] на [color=green]__3__[img=quantity-time][/color]![/font]
+message_milestone_reached_technology=[img=milestones_main_icon_white] [font=default-large-bold]Досліджено [color=green]__1____2__[/color] на [color=green]__3__[img=quantity-time][/color]![/font]
 message_settings_permission_denied=[color=red]Не вдається змінити налаштування віх. Вам потрібні права адміністратора.[/color]
 message_invalid_import_json=[color=red]Неправильний рядок імпорту. Цей рядок не є допустимим рядком JSON або закодованим рядком.[/color]
 message_invalid_import_type=[color=red]Неправильний рядок імпорту. Неправильний тип:[/color]


### PR DESCRIPTION
Formatting on non english locale was broken since version 1.4.2 (commit c5ca294)
This PR fixes that. To be on the safe side, locales that use different ordering (ko, zh-CN, zh-TW) weren't changed.