### PR TITLE
Register delayed chat event always and unconditionally

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -53,10 +53,6 @@ script.on_init(function()
     for _, player in pairs(game.players) do
         initialize_player(player)
     end
-
-    if next(storage.delayed_chat_messages) ~= nil then
-        create_delayed_chat()
-    end
 end)
 
 script.on_event(defines.events.on_surface_created, function(event)
@@ -90,9 +86,6 @@ script.on_event(defines.events.on_surface_deleted, function(event)
 end)
 
 script.on_load(function()
-    if storage.delayed_chat_messages ~= nil and next(storage.delayed_chat_messages) ~= nil then
-        create_delayed_chat()
-    end
     add_remote_presets_to_preset_tables()
 end)
 
@@ -152,10 +145,4 @@ script.on_configuration_changed(function(event)
     end
     remove_invalid_milestones_all_forces()
     remove_invalid_aliases()
-
-    -- We also do this here because for some reason on_nth_tick sometimes doesn't work in on_init
-    -- I don't know why
-    if next(storage.delayed_chat_messages) ~= nil then
-        create_delayed_chat()
-    end
 end)

--- a/scripts/util.lua
+++ b/scripts/util.lua
@@ -58,19 +58,17 @@ end
 local delayed_chat_delay = 240
 
 local function print_chat_delayed(event)
-    if event.tick == 0 then return end
+    if event.tick == 0 or storage.delayed_chat_messages == nil or next(storage.delayed_chat_messages) == nil then return end
     for _, delayed_chat_message in pairs(storage.delayed_chat_messages) do
         game.print(delayed_chat_message)
     end
     storage.delayed_chat_messages = {}
-    script.on_nth_tick(delayed_chat_delay, nil)
 end
 
-function create_delayed_chat()
-    script.on_nth_tick(delayed_chat_delay, function(event)
-        print_chat_delayed(event)
-    end)
-end
+-- Register event handler unconditionally
+script.on_nth_tick(delayed_chat_delay, function(event)
+    print_chat_delayed(event)
+end)
 
 function print_delayed_red(message)
     table.insert(storage.delayed_chat_messages, ({"", "[color=red]", message, "[/color]"}))


### PR DESCRIPTION
This should fix issue #30. With how little this event handler does, the best solution is to just keep it registered. It would be possible to refactor a bit so there's checks that ensure the handler is re-registered when needed, but I don't think that is worth the effort for a tiny micro-optimization.