### PR TITLE
Remove unused forces

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,9 @@
 ---------------------------------------------------------------------------------------------------
 Version: 1.4.8
 Date: ????
-  Changes:
+  Bugfixes:
+    - Fixed that some forces were being checked when those forces had no players resulting in performance degredation.
+
 ---------------------------------------------------------------------------------------------------
 Version: 1.4.7
 Date: 2025-11-23

--- a/scripts/migrations.lua
+++ b/scripts/migrations.lua
@@ -181,5 +181,14 @@ return {
         backfill_completion_times(force)
       end
     end
+  end,
+
+  ["1.4.8"] = function()
+    log("Running 1.4.8 migration")
+    for _, force in pairs(game.forces) do
+      if storage.forces[force.name] and not next(force.players) then
+        storage.forces[force.name] = nil
+      end
+    end
   end
 }


### PR DESCRIPTION
Noticed some UPS issues with milestones on a larger save. Looking into it, the cause is `storage.forces` containing entries without players doing multiple checks on flow statistics.

https://github.com/Wiwiweb/FactorioMilestones/blob/b09bf1c8062a9231b9dff4ffd2efe0f15ebe0649/scripts/storage_init.lua#L4
This line should ensure no forces without players are being added, however it appears the larger saves I was looking at had entries for forces such as "enemy" which should never be there. I assume those entries were from a previous version but I didn't go through the commit history to figure out how they got there. New games do not have these extra forces stored.

This PR just adds a migration to remove any existing forces without players. It does nothing to make sure that doesn't happen in the future but I don't see any reason it would.