### PR TITLE
Fix nullius preset dependencies

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,8 @@
 Version: 1.4.8
 Date: ????
   Changes:
+    - Removed angels smelting dependency from the nullius preset
+  
 ---------------------------------------------------------------------------------------------------
 Version: 1.4.7
 Date: 2025-11-23

--- a/presets/presets.lua
+++ b/presets/presets.lua
@@ -136,7 +136,7 @@ presets = {
 
 
     ["Nullius"] = {
-        required_mods = {"angelssmelting", "nullius"},
+        required_mods = {"nullius"},
         milestones = {
             {type="group",      name="Science"},
             {type="item",       name="nullius-geology-pack",             quantity=1},


### PR DESCRIPTION
Nullius for 2.0 is out, it no longer requires angels smithing, but the preset does so it wasn't getting found

https://mods.factorio.com/mod/nullius/dependencies