### PR TITLE
Fix remote interfaces (raise_milestone_reached_event)

### DIFF
--- a/scripts/remote_interface.lua
+++ b/scripts/remote_interface.lua
@@ -3,8 +3,8 @@ On_milestone_reached_event = nil -- global
 local interface = {}
 
 function interface.get_on_milestone_reached_event()
-	if not on_milestone_reached then on_milestone_reached = script.generate_event_name() end
-	return on_milestone_reached
+	if not On_milestone_reached_event then On_milestone_reached_event = script.generate_event_name() end
+	return On_milestone_reached_event
 end
 
 remote.add_interface("milestones", interface)

--- a/scripts/tracker.lua
+++ b/scripts/tracker.lua
@@ -16,6 +16,7 @@ local function raise_milestone_reached_event(force, milestone, message)
 		script.raise_event(On_milestone_reached_event, {
             force = force,
             milestone_name = milestone.name,
+            type = milestone.type,
             quantity = milestone.quantity,
             completion_tick = milestone.completion_tick,
             message = message

--- a/scripts/tracker.lua
+++ b/scripts/tracker.lua
@@ -15,7 +15,7 @@ local function raise_milestone_reached_event(force, milestone, message)
 	if On_milestone_reached_event then
 		script.raise_event(On_milestone_reached_event, {
             force = force,
-            name = milestone.name,
+            milestone_name = milestone.name,
             quantity = milestone.quantity,
             completion_tick = milestone.completion_tick,
             message = message


### PR DESCRIPTION
I've found 2 issues with the remote interface regarding the the `raise_milestone_reached_event`:

1. The event never fires because the variable was mismatching the global variable https://github.com/Wiwiweb/FactorioMilestones/blob/main/scripts/remote_interface.lua#L1-L8

2. The name property of the raised event gets overwritten by the engine with the event id, therefore I renamed it to milestone_name https://github.com/Wiwiweb/FactorioMilestones/blob/main/scripts/tracker.lua#L18

While at it, I've added the milestone type to the event.